### PR TITLE
Separate requirements for testing from dev

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -19,7 +19,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        python -m pip install '.[plotting,dev]'
+        python -m pip install '.[plotting,testing]'
         pip install flake8
     - name: Lint with flake8
       run: |

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -21,6 +21,7 @@ jobs:
       run: |
         python -m pip install '.[plotting,testing]'
         pip install flake8
+        pip freeze
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os:  [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ extras_require = {
         "pytest-subtests",
         "pytest-cov",
         "coveralls",
+        "nbconvert",
     ],
     "dev": [
         "pytest>=4.4.0",

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,12 @@ install_requires = [
 
 extras_require = {
     "plotting": ["matplotlib"],
+    "testing": [
+        "pytest>=4.4.0",
+        "pytest-subtests",
+        "pytest-cov",
+        "coveralls",
+    ],
     "dev": [
         "pytest>=4.4.0",
         "pytest-subtests",

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ install_requires = [
     "numpy",
     "scipy",
     "gitpython",
-    "sklearn",
+    "scikit-learn",
     "colorlog",
     "wilson != 2.2",
     "tqdm",


### PR DESCRIPTION
Reason: Newest sphinx leads to dependency conflicts with older python
versions, but it's not needed on most installations.
